### PR TITLE
Modified for late certificate provision

### DIFF
--- a/source/EetClient.php
+++ b/source/EetClient.php
@@ -2,9 +2,12 @@
 
 namespace Fritak\eet;
 
+use DOMDocument;
 use Fritak\eet\Certificate;
-use RobRichards\XMLSecLibs\XMLSecurityKey;
+use RobRichards\WsePhp\WSSESoap;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use SoapClient;
 
 /**
  * Soap client for data message.
@@ -13,7 +16,7 @@ use RobRichards\XMLSecLibs\XMLSecurityDSig;
  * @version 1.0
  * @package eet
  */
-class EetClient extends \SoapClient
+class EetClient extends SoapClient
 {
 
     /**
@@ -37,10 +40,10 @@ class EetClient extends \SoapClient
     public function __doRequest($request, $location, $saction, $version, $one_way = 0)
     {
         $XMLSecurityKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, ['type' => 'private']);
-        $DOMDocument = new \DOMDocument('1.0');
+        $DOMDocument = new DOMDocument('1.0');
 
         $DOMDocument->loadXML($request);
-        $WSSESoap = new \WSSESoap($DOMDocument);
+        $WSSESoap = new WSSESoap($DOMDocument);
 
         $XMLSecurityKey->loadKey($this->certificate->pkey);
 
@@ -52,5 +55,10 @@ class EetClient extends \SoapClient
 
         return parent::__doRequest($WSSESoap->saveXML(), $location, $saction, $version, $one_way);
     }
+    
+    public function setCertificate(Certificate $certificate){
+        $this->certificate = $certificate;
+    }
 
 }
+

--- a/source/Sender.php
+++ b/source/Sender.php
@@ -59,8 +59,10 @@ class Sender
         $this->requirements(); 
         
         $this->loadConfig($config);
-        $this->loadCertificate();
-        $this->loadEetClient();
+        if (isset($this->config['certificate'])){
+            $this->loadCertificate();
+            $this->loadEetClient();
+        }
     }
     
     
@@ -124,6 +126,10 @@ class Sender
      */
     public function send(Receipt $receipt)
     {
+        if (!$this->eetClient){
+            throw new ExceptionEet("No certificate provided!");
+        }
+        
         $data = $this->prepareDataForMessage($receipt);
 
         $response = $this->eetClient->OdeslaniTrzby($data);
@@ -177,6 +183,11 @@ class Sender
         $this->config['certificate']['password']    = $password;
 
         $this->loadCertificate();
+        if (!$this->eetClient){
+            $this->loadEetClient();
+        } else {
+            $this->eetClient->setCertificate($this->certificate);
+        }
     }
     
     /**
@@ -193,7 +204,6 @@ class Sender
         $this->config['defaultValues']['dic']       = $dic;
         $this->config['defaultValues']['id_provoz'] = $workshopId;
         $this->config['defaultValues']['id_pokl']   = $cashRegisterId;
-
     }
 
     /**
@@ -236,9 +246,8 @@ class Sender
         {
             throw new ExceptionEet('Please set config - Either path to the json file or array of values.', 202);
         }
-
-        if(!isset($this->config['certificate']['path']) ||
-           !isset($this->config['wsdlPath']))
+        
+        if(!isset($this->config['wsdlPath']))
         {
             throw new ExceptionEet('Some of mandatory keys in config are missing.', 203);
         }
@@ -317,3 +326,4 @@ class Sender
         return wordwrap(substr(sha1($sig), 0, 40) , 8 , '-' , true);
     }
 }
+


### PR DESCRIPTION
- Certificate is no longer mandatory in the initial config, if not provided it has to be set via changeCertificate method before calling send (otherwise EetException is thrown)

- changeCertificate now changes certificate in EetClient as well. If certificate was not provided via initial config and thus eetClient property is not initiated, changeCertificate initiates eetClient

- WSSESoap is now used from RobRichards\WsePhp package