### PR TITLE
BKP and PKP extraction, timeout support

### DIFF
--- a/example/config/config.json
+++ b/example/config/config.json
@@ -1,9 +1,9 @@
 {
     "certificate": {
-        "path": "app/eet-fritak/example/certificate/01000003.p12",
+        "path": "/home/martin/Development/Community/eet/example/certificate/01000003.p12",
         "password": "eet"
     },
-    "wsdlPath": "app/eet-fritak/example/soapFiles/EETServiceSOAP.wsdl",
+    "wsdlPath": "/home/martin/Development/Community/eet/example/soapFiles/EETServiceSOAP.wsdl",
     "defaultValues": {
         "dic_popl": "CZ1212121218",
         "id_provoz": "273",

--- a/example/config/config.json
+++ b/example/config/config.json
@@ -1,9 +1,9 @@
 {
     "certificate": {
-        "path": "/home/martin/Development/Community/eet/example/certificate/01000003.p12",
+        "path": "app/eet-fritak/example/certificate/01000003.p12",
         "password": "eet"
     },
-    "wsdlPath": "/home/martin/Development/Community/eet/example/soapFiles/EETServiceSOAP.wsdl",
+    "wsdlPath": "app/eet-fritak/example/soapFiles/EETServiceSOAP.wsdl",
     "defaultValues": {
         "dic_popl": "CZ1212121218",
         "id_provoz": "273",

--- a/example/config/config.json
+++ b/example/config/config.json
@@ -8,5 +8,7 @@
         "dic_popl": "CZ1212121218",
         "id_provoz": "273",
         "id_pokl": "1"
-    }
+    },
+    "timeout": 10,
+    "connectionTimeout": 3
 }

--- a/example/example.php
+++ b/example/example.php
@@ -5,17 +5,26 @@ ini_set('display_errors', 'On');
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
-use Fritak\eet\Sender;
+use Fritak\eet\ExceptionEet;
 use Fritak\eet\Receipt;
+use Fritak\eet\Sender;
 
-$sender = new Sender(__DIR__ . '/config.json'); // load Sender with configuration
+$sender = new Sender(__DIR__ . '/config/config.json'); // load Sender with configuration
 
 $sender->addReceipt(['uuid_zpravy' => 'b3a09b52-7c87-4014-a496-4c7a53cf9125', 'porad_cis' => 68, 'celk_trzba' => 546]);
 $sender->addReceipt(['uuid_zpravy' => 'b3a09b52-7c87-4014-a496-4c7a53cf9126', 'porad_cis' => 69, 'celk_trzba' => 748]);
 
-foreach ($sender->sendAllReceipts() AS $response)
-{
-    print $response->Potvrzeni->fik . '<br />'; // Your FIK - Fiscal Identification Code ("Fiskální identifikační kód")
+try {
+    foreach ($sender->sendAllReceipts() AS $response)
+    {
+        print $response->Potvrzeni->fik . '<br />'; // Your FIK - Fiscal Identification Code ("Fiskální identifikační kód")
+    }
+} catch (SoapFault $e) {
+    // Exception in communication
+    echo $e->getMessage();
+} catch (ExceptionEet $e){
+    // Exception in EET
+    echo $e->getMessage();
 }
 
 $receipt = new Receipt();
@@ -26,11 +35,19 @@ $receipt->celk_trzba = 546;
 $receipt->dic_popl = 'CZ1212121218';
 $receipt->id_provoz = '273';
 $receipt->id_pokl = '1';
-$receipt->dat_trzby = new \DateTime();
+$receipt->dat_trzby = new DateTime();
 
 // Now we try dry run. Returns boolean TRUE/FALSE
 if ($sender->dryRunSend($receipt))
 {
     // Send receipt
-    print $sender->send($receipt)->Potvrzeni->fik;
+    try {
+        print $sender->send($receipt)->Potvrzeni->fik;
+    } catch (SoapFault $e) {
+    // Exception in communication
+    echo $e->getMessage();
+    } catch (ExceptionEet $e){
+        // Exception in EET
+        echo $e->getMessage();
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,9 @@ Example of config:
         "dic_popl": "CZ1212121218",
         "id_provoz": "273",
         "id_pokl": "1"
-    }
+    },
+    "timeout": 10,
+    "connectionTimeout": 3
 }
 ```
 * Move certificate (PKCS#12) to your path. (See information on how to get one, or use the certificate from "/example/certificate" for playground - TEST only)

--- a/source/Exception/ExceptionEet.php
+++ b/source/Exception/ExceptionEet.php
@@ -4,6 +4,9 @@ namespace Fritak\eet;
 
 class ExceptionEet extends \Exception 
 {
+    const EET_CODE_OFFSET = 1000;
+    const BKP_MISMATCH_CODE = 2000;
+    
     public static $WARNING_CODE = 
     [
         1 => "DIC poplatnika v datove zprave se neshoduje s DIC v certifikatu (The taxpayer identification codes (DIČ) in the message and certificate differ)",

--- a/source/Receipt.php
+++ b/source/Receipt.php
@@ -183,6 +183,27 @@ class Receipt
      * @var string 
      */
     public $rezim = 0;
+    
+    /**
+     * PKP security code - set by the send() method
+     * 
+     * @var string
+     */
+    public $pkp;
+    
+    /**
+     * BKP security code - set by the send() method
+     * 
+     * @var string
+     */
+    public $bkp;
+    
+    /**
+     * FIK code - set by the send() method after successful request
+     * 
+     * @var string
+     */
+    public $fik;
 
     /**
      * Date and time of sending
@@ -295,3 +316,4 @@ class Receipt
     }
 
 }
+

--- a/source/Sender.php
+++ b/source/Sender.php
@@ -131,6 +131,9 @@ class Sender
         }
         
         $data = $this->prepareDataForMessage($receipt);
+        
+        $receipt->pkp = $data['KontrolniKody']['pkp']['_'];
+        $receipt->bkp = $data['KontrolniKody']['bkp']['_'];
 
         $response = $this->eetClient->OdeslaniTrzby($data);
 
@@ -148,6 +151,8 @@ class Sender
         {
             throw new ExceptionEet('EET communication check error, received BKP code is wrong!', 2000);
         }
+        
+        $receipt->fik = $response->Potvrzeni->fik;
 
         return $response;
     }


### PR DESCRIPTION
- Modified Receipt to include pkp, bkp and fik codes, send() method now modifies receipt by setting pkp, bkp and fik (if the request was successful).

- Added timeout support via "timeout" and "connectionTimeout" config options

- Defined hardcoded exception codes in ExceptionEet file